### PR TITLE
i18n&バリデーション追加

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -7,6 +7,7 @@ class Recipe < ApplicationRecord
   has_many :cooking_records, dependent: :nullify
   accepts_nested_attributes_for :recipe_ingredients, allow_destroy: true, reject_if: :all_blank
   after_initialize :set_default_is_public, if: :new_record?
+  validates :recipe_ingredients, presence: true
 
   def total_cost
     recipe_ingredients.to_a.sum(&:total_price) || 0

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -2,11 +2,11 @@
   <%= form_with(model: recipe, class: "space-y-10") do |f| %>
     
     <% if recipe.errors.any? %>
-      <div class="bg-red-50/50 border-2 border-red-100 p-6 rounded-[2rem]">
+      <div class="bg-red-50/50 border-2 border-red-100 p-6 rounded-[2rem] mb-8">
         <h3 class="text-sm font-black text-red-500 flex items-center gap-2">
-          <span>⚠️</span> 入力内容を確認してください
+          <span class="text-lg">⚠️</span> 入力内容を確認してください
         </h3>
-        <ul class="mt-2 text-xs text-red-400 list-disc list-inside font-bold">
+        <ul class="mt-3 text-xs text-red-400 list-disc list-inside font-bold space-y-1">
           <% recipe.errors.full_messages.each do |message| %>
             <li><%= message %></li>
           <% end %>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,3 +4,4 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
+bundle exec rails db:seed

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module Myapp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    config.i18n.default_locale = :ja
+
+    config.time_zone = "Tokyo"
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,6 +95,8 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
+  config.active_storage.service = :cloudinary
+
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  activerecord:
+    models:
+      recipe: "レシピ"
+    attributes:
+      recipe:
+        convenience_food: "コンビニ商品"
+        recipe_ingredients: "食材"
+    errors:
+      models:
+        recipe:
+          attributes:
+            convenience_food:
+              required: "を選択してください"
+            recipe_ingredients:
+              blank: "を1つ以上追加してください"
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      blank: "を入力してください"


### PR DESCRIPTION
## 実装内容
- i18n&バリデーション追加

## 変更点
- エラーメッセージのi18n化
- ```  validates :recipe_ingredients, presence: true```のバリデーション追加
- renderデプロイ時にdb/seed読み込み用にbin/render-build.shへ```bundle exec rails db:seed```追加

## 確認方法
- 正常にエラーメッセージが日本語で表示される

## 補足
- なし