### PR TITLE
fix:食材修正

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -48,8 +48,9 @@ class RecipesController < ApplicationController
   end
 
     @recipe = Recipe.new
-    3.times { @recipe.recipe_ingredients.build }
-    @ingredients = Ingredient.all.order(:id)
+    5.times { @recipe.recipe_ingredients.build }
+    @ingredients = Ingredient.all.order(:sort_order)
+    @convenience_foods = ConvenienceFood.all.order(:sort_order)
   end
 
   def show
@@ -61,7 +62,7 @@ class RecipesController < ApplicationController
   end
 
   def edit
-  @ingredients = Ingredient.all.order(:id)
+  @ingredients = Ingredient.all.order(:sort_order)
   end
 
 

--- a/app/views/recipes/_form.html.erb
+++ b/app/views/recipes/_form.html.erb
@@ -42,7 +42,7 @@
 
         <% 
           category_order = ["🍱 お弁当・丼・カレー", "🍝 パスタ・うどん・そば・ラーメン", "🥪 パン・サンドイッチ・おにぎり", "🍗 ホットスナック", "🥦 惣菜・サラダ", "💰 その他(金額目安)"]
-          all_foods = ConvenienceFood.all.order(:id)
+          all_foods = ConvenienceFood.all.order(:sort_order)
           grouped_options = category_order.map { |cat| [cat, all_foods.select { |f| f.category == cat }.map { |f| [f.name, f.id, { data: { price: f.price } }] }] } 
         %>
 

--- a/app/views/recipes/_ingredient_fields.html.erb
+++ b/app/views/recipes/_ingredient_fields.html.erb
@@ -2,7 +2,7 @@
   <div class="col-span-4 bg-white rounded p-1 shadow-sm border border-transparent focus-within:border-orange-200 transition-all">
     <% 
       categories = ["🥩 肉類", "🥬 野菜", "🐟 魚介類", "🥚 卵・乳製品・豆腐", "🍚 炭水化物（米・麺・パン）", "🧂 調味料・トッピング", "💰 その他（金額目安）"]
-      all_ingredients = Ingredient.all.order(:id)
+      all_ingredients = Ingredient.all.order(:sort_order)
       grouped_options = categories.map do |display_cat|
         ingredients_in_cat = all_ingredients.select { |i| i.category.present? && display_cat.include?(i.category) }
         [display_cat, ingredients_in_cat.map { |i| [i.name, i.id, { data: { price_per_gram: i.price_per_gram || 0 } }] }]

--- a/db/migrate/20260115223008_add_sort_order_to_ingredients.rb
+++ b/db/migrate/20260115223008_add_sort_order_to_ingredients.rb
@@ -1,0 +1,5 @@
+class AddSortOrderToIngredients < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ingredients, :sort_order, :integer
+  end
+end

--- a/db/migrate/20260115223034_add_sort_order_to_convenience_foods.rb
+++ b/db/migrate/20260115223034_add_sort_order_to_convenience_foods.rb
@@ -1,0 +1,5 @@
+class AddSortOrderToConvenienceFoods < ActiveRecord::Migration[7.2]
+  def change
+    add_column :convenience_foods, :sort_order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_15_154831) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_15_223034) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_15_154831) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "category"
+    t.integer "sort_order"
   end
 
   create_table "cooking_records", force: :cascade do |t|
@@ -68,6 +69,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_15_154831) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "category"
+    t.integer "sort_order"
   end
 
   create_table "recipe_ingredients", force: :cascade do |t|

--- a/db/seeds/ingredients.rb
+++ b/db/seeds/ingredients.rb
@@ -1,4 +1,4 @@
-puts "Updating ingredients (Safely)..."
+puts "Updating ingredients & convenience foods (Maintaining Order)..."
 
 ingredient_groups = {
   "🥩 肉類" => [
@@ -128,20 +128,18 @@ ingredient_groups = {
   ]
 }
 
+ing_order = 0
+
 ingredient_groups.each do |category_name, items|
   items.each do |item_data|
     ingredient = Ingredient.find_or_initialize_by(name: item_data[:name])
-    ingredient.update!(category: category_name, price_per_gram: item_data[:price_per_gram])
+    ingredient.update!(
+      category: category_name,
+      price_per_gram: item_data[:price_per_gram],
+      sort_order: ing_order
+    )
+    ing_order += 1
   end
 end
 
-active_ing_names = ingredient_groups.values.flatten.map { |i| i[:name] }
-unused_ings = Ingredient.where.not(name: active_ing_names).left_outer_joins(:recipe_ingredients).where(recipe_ingredients: { id: nil })
-puts "Deleting #{unused_ings.count} unused ingredients..."
-unused_ings.destroy_all
-
-Ingredient.where.not(name: active_ing_names).each do |ing|
-  ing.update(name: "【廃止】#{ing.name}") unless ing.name.start_with?("【廃止】")
-end
-
-puts "Success: Ingredients maintenance completed!"
+puts "Success: Ingredients and ConvenienceFoods maintenance completed!"


### PR DESCRIPTION
## 実装内容
- 食材を修正
- db/seed更新時に並び順が記述通りになるように修正

## 変更点
- db/seeds/ingredients.rb修正
- sort_orderカラム追加

## 確認方法
- 更新後の食材選択の順番がdb/seedと同じになっている

## 補足
- なし