### PR TITLE
fix: urlのOGP表示修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,7 @@
     
     <meta property="og:title" content="<%= content_for?(:og_title) ? yield(:og_title) : "自炊save" %>">
     <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : "「お得」を実感して、自炊がもっと好きになる。" %>">
-    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "https://#{request.host}/jisui_ogp.png" %>">
-    <meta name="twitter:card" content="summary_large_image">
+    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "https://jisui-save.onrender.com/jisui_ogp.png" %>">    <meta name="twitter:card" content="summary_large_image">
     <meta property="og:url" content="<%= request.original_url %>">
 
     <%= favicon_link_tag '/jisui-favicon.png', rel: 'icon', type: 'image/png' %>


### PR DESCRIPTION
## 実装内容
- urlを貼った時ののOGP表示修正

## 変更点
- <meta property="og:image"にURL直貼り(修正前は"https://#{request.host})

## 確認方法
- デプロイ後確認

## 補足
- URLを貼った時のアプリ（LINEやX）のキャッシュも削除済みなので、"https://#{request.host}が機能していなかったかと思われる