### PR TITLE
fix: 時間取得SQL修正

### DIFF
--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -13,8 +13,8 @@ namespace :notification do
 
     targets = NotificationSetting.includes(:user)
                                 .where("#{day_of_week} = ?", true)
-                                .where("EXTRACT(HOUR FROM (send_time AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) = ?", now.hour)
-                                .where("EXTRACT(MINUTE FROM (send_time AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) = ?", now.min)
+                                .where("EXTRACT(HOUR FROM send_time) = ?", now.hour)
+                                .where("EXTRACT(MINUTE FROM send_time) = ?", now.min)
                                 .where(enabled: true)
 
     puts "Found targets: #{targets.count}"


### PR DESCRIPTION
## 実装内容
- 本番環境での通知機能の取得が正常にできないため、取得するSQL分を修正

## 変更点
```
    targets = NotificationSetting.includes(:user)
                                .where("#{day_of_week} = ?", true)
                                .where("EXTRACT(HOUR FROM send_time) = ?", now.hour)
                                .where("EXTRACT(MINUTE FROM send_time) = ?", now.min)
                                .where(enabled: true)
```
のようにシンプルに時間を参照するように変更。

## 確認方法
- デプロイ後確認

## 補足
- USTとASTの違い？