### PR TITLE
fix: 通知コントローラー修正

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,8 +6,15 @@ class NotificationsController < ApplicationController
   end
 
   def update
+      logger.debug "--- DEBUG: Params received: #{params[:notification_setting].inspect} ---"
       @setting = current_user.notification_setting
-      if @setting.update(notification_params)
+
+      p_hash = notification_params
+      if p_hash[:send_time].present?
+        p_hash[:send_time] = Time.zone.parse(p_hash[:send_time])
+      end
+
+      if @setting.update(p_hash)
         redirect_to profile_path, notice: "通知設定を更新しました"
       else
         render :edit, status: :unprocessable_entity


### PR DESCRIPTION
## 実装内容
- fix: 通知コントローラー修正

## 変更点
- アプリ側で通知のデータが保存されないため、デバックコード月で修正
- 

## 確認方法
- デプロイ後確認

## 補足
- ローカルではできている。
- rails consoleで手動入力でも機能している
- 自動化だけできていない。