### PR TITLE
add: flash-timeout実装

### DIFF
--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    setTimeout(() => {
+      this.dismiss()
+    }, 3000)
+  }
+
+  dismiss() {
+    this.element.style.opacity = "0"
+    this.element.style.transition = "opacity 0.5s ease"
+    
+    setTimeout(() => {
+      this.element.remove()
+    }, 500)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import FlashController from "./flash_controller"
+application.register("flash", FlashController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
 
     <main>
       <% flash.each do |message_type, message| %>
-        <div class="max-w-md mx-auto mt-4 px-4 py-3 rounded-xl shadow-sm text-center font-bold <%= message_type == 'notice' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' %>">
+        <div data-controller="flash" class="max-w-md mx-auto mt-4 px-4 py-3 rounded-xl shadow-sm text-center font-bold <%= message_type == 'notice' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700' %>">
           <%= message %>
         </div>
       <% end %>


### PR DESCRIPTION
## 実装内容
- flash-timeout実装してメッセージを自動でタイムアウトする

## 変更点
- app/javascript/controllers/flash_controller.js作成
- app/views/layouts/application.html.erbで
```
data-controller="flash"
```
を追加し、全ページに適用

## 確認方法
- 正常にフラッシュメッセージが消える

## 補足
- なし