### PR TITLE
fix: ゲストログインのリダイレクト修正

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -50,6 +50,6 @@ def create
       u.uid = "guest"
     end
     session[:user_id] = user.id
-    redirect_to recipes_path, notice: "ゲストとしてログインしました（閲覧専用）"
+    redirect_to recipes_path, notice: "ゲストとしてログインしました（閲覧専用）", status: :see_other
   end
 end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -43,7 +43,7 @@
         <div class="relative flex justify-center text-[10px] uppercase font-black tracking-widest text-stone-300"><span class="bg-white px-4">OR</span></div>
       </div>
 
-      <%= button_to guest_login_path, method: :post, class: "flex items-center justify-center gap-3 w-full py-4 px-4 rounded-2xl bg-gradient-to-r from-orange-400 to-orange-500 hover:from-orange-500 hover:to-orange-600 text-white font-black shadow-lg shadow-orange-200 transition-all active:scale-[0.98]" do %>
+      <%= button_to guest_login_path, method: :post, data: { turbo: false }, class: "flex items-center justify-center gap-3 w-full py-4 px-4 rounded-2xl bg-gradient-to-r from-orange-400 to-orange-500 hover:from-orange-500 hover:to-orange-600 text-white font-black shadow-lg shadow-orange-200 transition-all active:scale-[0.98]" do %>
         <span class="text-xl">🍳</span>
         ゲストログインでお試し
         <span class="text-[10px] font-bold opacity-80 tracking-tight">


### PR DESCRIPTION
## 実装内容
- fix: ゲストログインのリダイレクト修正

## 変更点
- turbo_frameが原因だったためdata: { turbo: false },で対応

## 確認方法
- 正常にリダイレクトする

## 補足
- なし