### PR TITLE
fix: カスタムドメインへ変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 自炊save
 ![サムネ](jisui-OGP.png)
-[自炊save](https://jisui-save.onrender.com)
+[自炊save](https://jisui-save.com)
 
 ## サービス概要
 「自炊って本当にお得なの？」の答えを数字で教えてくれるアプリです。

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,9 +14,9 @@
     
     <meta property="og:title" content="<%= content_for?(:og_title) ? yield(:og_title) : "自炊save" %>">
     <meta property="og:description" content="<%= content_for?(:og_description) ? yield(:og_description) : "「お得」を実感して、自炊がもっと好きになる。" %>">
-    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "https://jisui-save.onrender.com/jisui_ogp.png" %>">    <meta name="twitter:card" content="summary_large_image">
+    <meta property="og:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "https://jisui-save.com/jisui_ogp.png" %>">    <meta name="twitter:card" content="summary_large_image">
     <meta property="og:url" content="<%= request.original_url %>">
-    <meta name="twitter:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "[https://jisui-save.onrender.com/jisui_ogp.png](https://jisui-save.onrender.com/jisui_ogp.png)" %>">
+    <meta name="twitter:image" content="<%= content_for?(:og_image) ? yield(:og_image) : "[https://jisui-save.com/jisui_ogp.png](https://jisui-save.com/jisui_ogp.png)" %>">
 
     <%= favicon_link_tag '/jisui-favicon.png', rel: 'icon', type: 'image/png' %>
     <%= yield :head %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,8 +97,8 @@ Rails.application.configure do
 
   config.active_storage.service = :cloudinary
 
-  config.action_controller.default_url_options = { host: "jisui-save.onrender.com", protocol: "https" }
-  config.asset_host = "https://jisui-save.onrender.com"
+  config.action_controller.default_url_options = { host: "jisui-save.com", protocol: "https" }
+  config.asset_host = "https://jisui-save.com"
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -40,7 +40,7 @@ namespace :notification do
       line_user_id = setting.user&.line_user_id
       next if line_user_id.blank?
 
-      action = Line::Bot::V2::MessagingApi::URIAction.new(label: "レシピを探す", uri: "https://jisui-save.onrender.com")
+      action = Line::Bot::V2::MessagingApi::URIAction.new(label: "レシピを探す", uri: "https://jisui-save.com")
       template = Line::Bot::V2::MessagingApi::ButtonsTemplate.new(text: "自炊の時間です！🍳", actions: [ action ])
       message = Line::Bot::V2::MessagingApi::TemplateMessage.new(type: "template", alt_text: "自炊の時間になりました🍳", template: template)
       push_request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(to: line_user_id, messages: [ message ])


### PR DESCRIPTION
## 実装内容
- renderで取得しているドメインをカスタムドメインへ変更

## 変更点
- お名前.comでドメイン取得
- renderのIPアドレスを取得し、お名前.comで作った新しいドメインに変更
- config/environments/production.rbとRakeタスクのURL変更
- LINE Developersとgoogle consoleのURL変更

## 確認方法
- デプロイ後、新しいURLで正常に表示ができる

## 補足
- https://jisui-save.onrender.comからhttps://jisui-save.comへ変更