### PR TITLE
LINE連携時のログインskipを追記

### DIFF
--- a/app/controllers/line_events_controller.rb
+++ b/app/controllers/line_events_controller.rb
@@ -1,4 +1,5 @@
 class LineEventsController < ApplicationController
+  skip_before_action :require_login, raise: false
   protect_from_forgery except: [ :callback ]
 
   def callback


### PR DESCRIPTION
## 実装内容
- ログインバリデーションが、LINE連携のWebhookに効いているのをスキップ

## 変更点
- skip_before_actionでリダイレクトを通す

## 確認方法
- デプロイ後、LINE Developersで検証

## 補足
- 多分これで検証通って自動友達追加ができるはず。無理なら通信ではなくURL設定とかのタイポかな？